### PR TITLE
Убрал возврат кода 404. Оставил возврат пустого списка

### DIFF
--- a/app/routers/card.py
+++ b/app/routers/card.py
@@ -97,11 +97,11 @@ def read_user_cards(
         .where(Card.user_id == user_id)
     ).all()
     
-    if not cards:
-        raise HTTPException(
-            status_code=404,
-            detail=f"No cards found for user with id {user_id}"
-        )
+    # if not cards:
+    #     raise HTTPException(
+    #         status_code=404,
+    #         detail=f"No cards found for user with id {user_id}"
+    #     )
     
     return cards
 


### PR DESCRIPTION
При отсутствии карточек у пользователя апи возвращало код 404. 
Теперь возвращает просто пустой список